### PR TITLE
Updated txt draft and generating tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-draft-ietf-teep-otrp-over-http.txt: draft-ietf-teep-otrp-over-http.xml
-	xml2rfc draft-ietf-teep-otrp-over-http.xml
 
-draft-ietf-teep-otrp-over-http.xml: draft-ietf-teep-otrp-over-http.md
-	kramdown-rfc2629 draft-ietf-teep-otrp-over-http.md > draft-ietf-teep-otrp-over-http.xml
+IETF_MD := draft-ietf-teep-otrp-over-http.md
+
+XML_FILES := $(subst .md,.xml, $(IETF_MD))
+TXT_FILES := $(subst .md,.txt, $(IETF_MD))
+
+$(TXT_FILES): $(IETF_MD)
+	kdrfc $^
+
+.PHONY: all clean
+clean:
+	rm -f $(TXT_FILES) $(XML_FILES)

--- a/README.md
+++ b/README.md
@@ -13,4 +13,21 @@ Formatted text and HTML versions of the draft can be built using `make`.
 $ make
 ``` 
 
+Regenerating files after updating markdown file.
+```sh
+$ make clean
+$ make
+```
+
 This requires that you have the necessary software installed.
+
+Debian/Ubuntu
+```sh
+$ sudo apt install ruby-kramdown-rfc2629
+```
+
+Fedora
+```sh
+$ sudo dnf install rubygems
+$ sudo gem install kramdown-rfc2629
+```

--- a/draft-ietf-teep-otrp-over-http.txt
+++ b/draft-ietf-teep-otrp-over-http.txt
@@ -4,8 +4,8 @@
 
 TEEP WG                                                        D. Thaler
 Internet-Draft                                                 Microsoft
-Intended status: Informational                         February 10, 2020
-Expires: August 13, 2020
+Intended status: Informational                            March 11, 2020
+Expires: September 12, 2020
 
 
 HTTP Transport for Trusted Execution Environment Provisioning: Agent-to-
@@ -31,14 +31,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 13, 2020.
+   This Internet-Draft will expire on September 12, 2020.
 
 Copyright Notice
 
@@ -47,15 +47,15 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
 
 
 
-Thaler                   Expires August 13, 2020                [Page 1]
+Thaler                 Expires September 12, 2020               [Page 1]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    to this document.  Code Components extracted from this document must
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Thaler                   Expires August 13, 2020                [Page 2]
+Thaler                 Expires September 12, 2020               [Page 2]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    allowing code (e.g., TCP/IP) that only sees encrypted messages, to be
@@ -165,9 +165,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 3]
+Thaler                 Expires September 12, 2020               [Page 3]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
 2.  Terminology
@@ -221,9 +221,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 4]
+Thaler                 Expires September 12, 2020               [Page 4]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
                            Model:    A      B      C     ...
@@ -277,9 +277,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 5]
+Thaler                 Expires September 12, 2020               [Page 5]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    Some TEE architectures (e.g., SGX) may support API calls both into
@@ -333,9 +333,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 6]
+Thaler                 Expires September 12, 2020               [Page 6]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
 5.  TEEP/HTTP Client Behavior
@@ -389,9 +389,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 7]
+Thaler                 Expires September 12, 2020               [Page 7]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    empty body.  The HTTP request is then associated with the TEEP/HTTP
@@ -445,9 +445,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 8]
+Thaler                 Expires September 12, 2020               [Page 8]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    If instead the TEEP implementation passes back a message buffer, the
@@ -501,9 +501,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020                [Page 9]
+Thaler                 Expires September 12, 2020               [Page 9]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
 6.1.  Receiving an HTTP POST request
@@ -557,9 +557,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020               [Page 10]
+Thaler                 Expires September 12, 2020              [Page 10]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
         had a cached TAM certificate that it trusts, it could skip to
@@ -613,9 +613,9 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020               [Page 11]
+Thaler                 Expires September 12, 2020              [Page 11]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
           POST /tam HTTP/1.1
@@ -663,31 +663,31 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
    [I-D.ietf-httpbis-semantics]
               Fielding, R., Nottingham, M., and J. Reschke, "HTTP
-              Semantics", draft-ietf-httpbis-semantics-06 (work in
-              progress), November 2019.
+              Semantics", draft-ietf-httpbis-semantics-07 (work in
+              progress), March 2020.
 
 
 
 
-Thaler                   Expires August 13, 2020               [Page 12]
+Thaler                 Expires September 12, 2020              [Page 12]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    [I-D.ietf-teep-protocol]
               Tschofenig, H., Pei, M., Wheeler, D., and D. Thaler,
               "Trusted Execution Environment Provisioning (TEEP)
-              Protocol", draft-ietf-teep-protocol-00 (work in progress),
-              December 2019.
+              Protocol", draft-ietf-teep-protocol-01 (work in progress),
+              March 2020.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818,
-              DOI 10.17487/RFC2818, May 2000, <https://www.rfc-
-              editor.org/info/rfc2818>.
+              DOI 10.17487/RFC2818, May 2000,
+              <https://www.rfc-editor.org/info/rfc2818>.
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
@@ -698,8 +698,8 @@ Internet-Draft             TEEP HTTP Transport             February 2020
    [GP-OTrP]  Global Platform, "TEE Management Framework: Open Trust
               Protocol (OTrP) Profile Version 1.0", Global
               Platform GPD_SPE_123, May 2019,
-              <https://globalplatform.org/specs-library/tee-management-
-              framework-open-trust-protocol/>.
+              <https://globalplatform.org/specs-library/
+              tee-management-framework-open-trust-protocol/>.
 
    [I-D.ietf-httpbis-bcp56bis]
               Nottingham, M., "Building Protocols with HTTP", draft-
@@ -709,8 +709,8 @@ Internet-Draft             TEEP HTTP Transport             February 2020
    [I-D.ietf-teep-architecture]
               Pei, M., Tschofenig, H., Thaler, D., and D. Wheeler,
               "Trusted Execution Environment Provisioning (TEEP)
-              Architecture", draft-ietf-teep-architecture-06 (work in
-              progress), February 2020.
+              Architecture", draft-ietf-teep-architecture-07 (work in
+              progress), March 2020.
 
    [I-D.ietf-teep-opentrustprotocol]
               Pei, M., Atyeo, A., Cook, N., Yoo, M., and H. Tschofenig,
@@ -725,9 +725,9 @@ Author's Address
 
 
 
-Thaler                   Expires August 13, 2020               [Page 13]
+Thaler                 Expires September 12, 2020              [Page 13]
 
-Internet-Draft             TEEP HTTP Transport             February 2020
+Internet-Draft             TEEP HTTP Transport                March 2020
 
 
    Dave Thaler
@@ -781,4 +781,4 @@ Internet-Draft             TEEP HTTP Transport             February 2020
 
 
 
-Thaler                   Expires August 13, 2020               [Page 14]
+Thaler                 Expires September 12, 2020              [Page 14]


### PR DESCRIPTION
I improved generating draft from markdown file with the tools from IETF 104. 
https://datatracker.ietf.org/meeting/104/materials/slides-104-edu-sessf-how-to-create-an-internet-draft-using-xml-or-markdown-markdown-01

Confirmed works on both debian/ubuntu and fedora.

Thanks,
-Akira